### PR TITLE
Adding Traditional Chinese

### DIFF
--- a/lib/iso639/ISO-639-2_utf-8.txt
+++ b/lib/iso639/ISO-639-2_utf-8.txt
@@ -76,7 +76,7 @@ cha||ch|Chamorro|chamorro
 chb|||Chibcha|chibcha
 che||ce|Chechen|tchétchène
 chg|||Chagatai|djaghataï
-chi|zho|zh|Chinese|chinois
+chi||zh|Chinese (Simplified)|chinois
 chk|||Chuukese|chuuk
 chm|||Mari|mari
 chn|||Chinook jargon|chinook, jargon
@@ -479,6 +479,7 @@ zbl|||Blissymbols; Blissymbolics; Bliss|symboles Bliss; Bliss
 zen|||Zenaga|zenaga
 zgh|||Standard Moroccan Tamazight|amazighe standard marocain
 zha||za|Zhuang; Chuang|zhuang; chuang
+zho|||Chinese (Traditional)|chinois
 znd|||Zande languages|zandé, langues
 zul||zu|Zulu|zoulou
 zun|||Zuni|zuni


### PR DESCRIPTION
There's currently Simplified Chinese. We need support for Traditional Chinese as we're integrated with Wistia. I _believe_ they expect an Iso639 code like `zho`

https://chinese.stackexchange.com/questions/6147/which-one-of-these-two-iso-639-2-code-refers-to-traditional-chinese-chi-or-zho

<img width="1733" alt="56319424-816ba100-6116-11e9-986d-e8ea83478533" src="https://user-images.githubusercontent.com/2831414/57469476-97631200-723b-11e9-8402-450581d622b8.png">
